### PR TITLE
Add initial Kraken UserMng plugin scaffold

### DIFF
--- a/wp-content/plugins/kraken-user-mng/README.md
+++ b/wp-content/plugins/kraken-user-mng/README.md
@@ -1,0 +1,11 @@
+# Kraken UserMng
+
+This plugin provides a starting point for a private coach area with events and file sharing.
+
+## Features
+
+* Registers `coach` role.
+* Custom post types `kum_event` and `kum_file`.
+* Ready for translations via `kraken-user-mng` text domain.
+
+> **Note:** This is a minimal scaffold; full functionality as described in the specification must be implemented separately.

--- a/wp-content/plugins/kraken-user-mng/kraken-user-mng.php
+++ b/wp-content/plugins/kraken-user-mng/kraken-user-mng.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Plugin Name: Kraken UserMng
+ * Plugin URI: https://example.com/
+ * Description: Provides a private area for coaches with events and file sharing.
+ * Version: 0.1.0
+ * Author: Kraken Design
+ * Text Domain: kraken-user-mng
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+class Kraken_UserMng {
+    /**
+     * Initialize hooks.
+     */
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_role' ] );
+        add_action( 'init', [ $this, 'register_post_types' ] );
+        add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
+    }
+
+    /**
+     * Load plugin text domain for translations.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'kraken-user-mng', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    }
+
+    /**
+     * Register custom user role for coaches.
+     */
+    public function register_role() {
+        if ( ! get_role( 'coach' ) ) {
+            add_role( 'coach', __( 'Coach', 'kraken-user-mng' ), [
+                'read'         => true,
+                'upload_files' => true,
+            ] );
+        }
+    }
+
+    /**
+     * Register custom post types for events and files.
+     */
+    public function register_post_types() {
+        register_post_type( 'kum_event', [
+            'labels' => [
+                'name'          => __( 'Events', 'kraken-user-mng' ),
+                'singular_name' => __( 'Event', 'kraken-user-mng' ),
+            ],
+            'public'      => false,
+            'show_ui'     => true,
+            'supports'    => [ 'title', 'editor' ],
+            'show_in_menu'=> true,
+            'capability_type' => 'post',
+        ] );
+
+        register_post_type( 'kum_file', [
+            'labels' => [
+                'name'          => __( 'Files', 'kraken-user-mng' ),
+                'singular_name' => __( 'File', 'kraken-user-mng' ),
+            ],
+            'public'      => false,
+            'show_ui'     => true,
+            'supports'    => [ 'title' ],
+            'show_in_menu'=> true,
+            'capability_type' => 'post',
+        ] );
+    }
+}
+
+new Kraken_UserMng();
+
+register_activation_hook( __FILE__, function() {
+    ( new Kraken_UserMng() )->register_role();
+} );

--- a/wp-content/plugins/kraken-user-mng/languages/kraken-user-mng.pot
+++ b/wp-content/plugins/kraken-user-mng/languages/kraken-user-mng.pot
@@ -1,0 +1,29 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Kraken UserMng 0.1.0\n"
+"POT-Creation-Date: 2023-01-01 00:00+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: ChatGPT\n"
+"Domain: kraken-user-mng\n"
+
+#: kraken-user-mng.php:33
+msgid "Coach"
+msgstr ""
+
+#: kraken-user-mng.php:47
+msgid "Events"
+msgstr ""
+
+#: kraken-user-mng.php:48
+msgid "Event"
+msgstr ""
+
+#: kraken-user-mng.php:57
+msgid "Files"
+msgstr ""
+
+#: kraken-user-mng.php:58
+msgid "File"
+msgstr ""

--- a/wp-content/plugins/kraken-user-mng/wpml-config.xml
+++ b/wp-content/plugins/kraken-user-mng/wpml-config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wpml-config>
+  <admin-texts>
+    <key name="kraken_user_mng_options" />
+  </admin-texts>
+  <custom-types>
+    <custom-type translate="1">kum_event</custom-type>
+    <custom-type translate="1">kum_file</custom-type>
+  </custom-types>
+  <custom-fields>
+    <custom-field action="copy">assigned_coach</custom-field>
+    <custom-field action="copy">created_by</custom-field>
+  </custom-fields>
+</wpml-config>


### PR DESCRIPTION
## Summary
- add Kraken UserMng plugin skeleton with coach role and custom post types for events and files
- include translation template and WPML configuration

## Testing
- `php -l wp-content/plugins/kraken-user-mng/kraken-user-mng.php`

------
https://chatgpt.com/codex/tasks/task_e_68a88ef15b5c83239dacf1a9e8e2fb19